### PR TITLE
chore: remove snakefile from snakeprofile for fluffy

### DIFF
--- a/snakemake-profiles/fluffy/config.yaml
+++ b/snakemake-profiles/fluffy/config.yaml
@@ -6,7 +6,6 @@ max-jobs-per-second: 100
 resources: load=100
 max-status-checks-per-second: 100
 use-singularity: True
-snakefile: "/projects/wp2/nobackup/CGU_2021_5_GMS_akuta_leukemier_WGS/Bin/wgs_leukemia_konigskobra/workflow/Snakefile"
 drmaa: "-p {resources.partition} -t {resources.time} -n {resources.threads} --mem={resources.mem_mb} --mem-per-cpu={resources.mem_per_cpu} {resources.gres} -J {rule} -A wp2 -e slurm/{rule}_%j.err -o slurm/{rule}_%j.out --nodes=1-1"
 default-resources: [gres=""]
 drmaa-log-dir: "slurm"


### PR DESCRIPTION
Should not contain snakefile since the path to snakefile will depend on fluffy-version for clinical processing e.g. `${bin_path}/fluffy/${fluffy_version}/fluffy_hematology_wgs/workflow/Snakefile`